### PR TITLE
Rename batch_size to inference_chunk_size for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ niftilearn/
 niftilearn --config example_config.yaml train
 
 # Train with parameter overrides
-niftilearn --config example_config.yaml train --epochs 50 --batch-size 4 --learning-rate 5e-5
+niftilearn --config example_config.yaml train --epochs 50 --inference-chunk-size 4 --learning-rate 5e-5
 
 # Multi-GPU training with torchrun
 torchrun --nproc_per_node=2 -m niftilearn.cli.main --config example_config.yaml train
@@ -134,7 +134,7 @@ data:
   val_split: 0.2
   test_split: 0.1
   slice_axis: 2                        # Extract sagittal slices
-  batch_size: 8                        # Slices per batch from same volume
+  inference_chunk_size: 8              # Number of slices processed at once during inference
   img_size: [224, 224]                 # Target 2D slice size
   use_adaptive_hu_normalization: true  # Adaptive HU windowing
 
@@ -147,7 +147,7 @@ model:
 
 training:
   epochs: 100
-  batch_size: 8                        # Must match data.batch_size
+  inference_chunk_size: 8              # Must match data.inference_chunk_size
   learning_rate: 1e-4
   optimizer: "AdamW"
   loss_function: "dicece"              # MONAI loss functions

--- a/bin/example_datamodule_usage.py
+++ b/bin/example_datamodule_usage.py
@@ -13,21 +13,23 @@ from niftilearn.data import NiftiDataModule
 
 def main():
     """Main example function demonstrating NiftiDataModule usage."""
-    
+
     # Example configuration
     data_config = DataConfig(
         data_dir=Path("/path/to/nifti/data"),
-        annotation_dir=Path("/path/to/annotations"),  # Not used in current implementation
+        annotation_dir=Path(
+            "/path/to/annotations"
+        ),  # Not used in current implementation
         train_split=0.7,
         val_split=0.2,
         test_split=0.1,
         slice_axis=2,  # Axial slices
-        batch_size=8,  # Will be overridden to 1 for volume-based processing
+        inference_chunk_size=8,  # Used for inference memory management, not training batching
         img_size=[224, 224],
         target_spacing=[1.0, 1.0, 1.0],
         target_size=[224, 224, 64],
     )
-    
+
     compute_config = ComputeConfig(
         devices="auto",
         accelerator="gpu",
@@ -35,29 +37,31 @@ def main():
         precision="16-mixed",
         num_workers=4,
     )
-    
+
     # Initialize DataModule
     datamodule = NiftiDataModule(
         data_config=data_config,
         compute_config=compute_config,
         annotation_type="ART",  # Target artery annotations
-        enable_caching=True,    # Cache volumes for faster loading
-        cache_size=10,          # Cache up to 10 volumes per dataset split
-        random_seed=42,         # For reproducible splits
+        enable_caching=True,  # Cache volumes for faster loading
+        cache_size=10,  # Cache up to 10 volumes per dataset split
+        random_seed=42,  # For reproducible splits
     )
-    
+
     # Setup data discovery and dataset creation
     print("Setting up data discovery...")
     datamodule.setup()
-    
+
     # Get discovery summary
     summary = datamodule.get_discovery_summary()
     if summary:
-        print(f"Data Discovery Summary:")
+        print("Data Discovery Summary:")
         print(f"  Total subjects: {summary['total_subjects']}")
-        print(f"  Subjects with {datamodule.annotation_type}: {summary['subjects_with_target_annotation']}")
+        print(
+            f"  Subjects with {datamodule.annotation_type}: {summary['subjects_with_target_annotation']}"
+        )
         print(f"  Available annotation types: {summary['annotation_types']}")
-    
+
     # Get dataset information
     dataset_info = datamodule.get_dataset_info()
     print("\nDataset Information:")
@@ -65,38 +69,42 @@ def main():
         print(f"  {split_name}:")
         print(f"    Volumes: {info['num_volumes']}")
         print(f"    Caching: {info['cache_enabled']}")
-        print(f"    Cache utilization: {info['cache_stats']['utilization']:.1%}")
-    
+        print(
+            f"    Cache utilization: {info['cache_stats']['utilization']:.1%}"
+        )
+
     # Create data loaders
     train_loader = datamodule.train_dataloader()
     val_loader = datamodule.val_dataloader()
     test_loader = datamodule.test_dataloader()
-    
-    print(f"\nDataLoaders Created:")
+
+    print("\nDataLoaders Created:")
     print(f"  Train batches (volumes): {len(train_loader)}")
     print(f"  Val batches (volumes): {len(val_loader)}")
     print(f"  Test batches (volumes): {len(test_loader) if test_loader else 0}")
-    
+
     # Example: Iterate through one training batch
     print("\nExample Training Batch:")
     for batch_idx, batch in enumerate(train_loader):
         print(f"  Batch {batch_idx}:")
-        print(f"    Volume shape: {batch['volume'].shape}")  # [N_slices, C, H, W]
+        print(
+            f"    Volume shape: {batch['volume'].shape}"
+        )  # [N_slices, C, H, W]
         print(f"    Segmentation shape: {batch['segmentation'].shape}")
         print(f"    Subject ID: {batch['subject_id']}")
         print(f"    Annotation type: {batch['annotation_type']}")
         print(f"    Number of slices: {batch['num_slices']}")
-        
+
         # Only show first batch for demonstration
         break
-    
+
     # Validate configuration
     validation = datamodule.validate_configuration()
-    print(f"\nConfiguration Validation:")
+    print("\nConfiguration Validation:")
     print(f"  Valid: {validation['valid']}")
-    if validation['issues']:
+    if validation["issues"]:
         print(f"  Issues: {validation['issues']}")
-    if validation['recommendations']:
+    if validation["recommendations"]:
         print(f"  Recommendations: {validation['recommendations']}")
 
 

--- a/bin/test_unet2d_integration.py
+++ b/bin/test_unet2d_integration.py
@@ -8,7 +8,7 @@ batches and produces expected output shapes for segmentation tasks.
 import argparse
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from loguru import logger
@@ -30,7 +30,7 @@ def setup_logging() -> None:
 
 def parse_arguments() -> argparse.Namespace:
     """Parse command line arguments.
-    
+
     Returns:
         Parsed arguments namespace
     """
@@ -44,13 +44,13 @@ Examples:
   python bin/test_unet2d_integration.py /path/to/data --device cpu
         """,
     )
-    
+
     parser.add_argument(
         "data_dir",
         type=Path,
         help="Path to NIFTI data directory containing subject folders",
     )
-    
+
     parser.add_argument(
         "--annotation-type",
         type=str,
@@ -58,14 +58,14 @@ Examples:
         choices=["ART", "RA", "S_FAT"],
         help="Annotation type to test (default: ART)",
     )
-    
+
     parser.add_argument(
         "--device",
         type=str,
         default="auto",
         help="Device to use for testing (auto, cpu, gpu, cuda) (default: auto)",
     )
-    
+
     parser.add_argument(
         "--img-size",
         type=int,
@@ -74,7 +74,7 @@ Examples:
         metavar=("HEIGHT", "WIDTH"),
         help="Image size for model input (default: 224 224)",
     )
-    
+
     parser.add_argument(
         "--slice-axis",
         type=int,
@@ -82,63 +82,67 @@ Examples:
         choices=[0, 1, 2],
         help="Slice axis for 2D extraction (0=sagittal, 1=coronal, 2=axial) (default: 2)",
     )
-    
+
     parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable verbose debugging output",
     )
-    
+
     return parser.parse_args()
 
 
 def validate_data_directory(data_dir: Path) -> None:
     """Validate that the provided data directory exists and is accessible.
-    
+
     Args:
         data_dir: Path to data directory
-        
+
     Raises:
         SystemExit: If directory is invalid
     """
     if not data_dir.exists():
         logger.error(f"Data directory does not exist: {data_dir}")
         sys.exit(1)
-        
+
     if not data_dir.is_dir():
         logger.error(f"Path is not a directory: {data_dir}")
         sys.exit(1)
-        
+
     # Check for some basic structure (subject directories)
     subdirs = [p for p in data_dir.iterdir() if p.is_dir()]
     if not subdirs:
         logger.warning(f"No subdirectories found in {data_dir}")
-        logger.warning("Expected structure: data_dir/subject_id/study_volume/*.nii.gz")
-    
+        logger.warning(
+            "Expected structure: data_dir/subject_id/study_volume/*.nii.gz"
+        )
+
     logger.info(f"✓ Data directory validated: {data_dir}")
     logger.info(f"  Found {len(subdirs)} potential subject directories")
 
 
-def create_test_configurations(args: argparse.Namespace) -> tuple[DataConfig, ModelConfig, ComputeConfig]:
+def create_test_configurations(
+    args: argparse.Namespace,
+) -> tuple[DataConfig, ModelConfig, ComputeConfig]:
     """Create configuration objects for testing.
-    
+
     Args:
         args: Parsed command line arguments
-        
+
     Returns:
         Tuple of (DataConfig, ModelConfig, ComputeConfig)
     """
     logger.info("Creating test configurations...")
-    
+
     # Data configuration
     data_config = DataConfig(
         data_dir=args.data_dir,
         annotation_dir=args.data_dir,  # Same directory for annotations
         train_split=0.7,
-        val_split=0.2, 
+        val_split=0.2,
         test_split=0.1,
         slice_axis=args.slice_axis,
-        batch_size=8,  # Will be overridden by DataModule
+        inference_chunk_size=8,  # Used for inference memory management
         img_size=args.img_size,
         target_spacing=[1.0, 1.0, 1.0],
         target_size=[args.img_size[0], args.img_size[1], 64],
@@ -146,7 +150,7 @@ def create_test_configurations(args: argparse.Namespace) -> tuple[DataConfig, Mo
         adaptive_hu_lower_percentile=0.5,
         adaptive_hu_upper_percentile=99.5,
     )
-    
+
     # Model configuration
     model_config = ModelConfig(
         img_size=args.img_size,
@@ -157,48 +161,58 @@ def create_test_configurations(args: argparse.Namespace) -> tuple[DataConfig, Mo
         spatial_dims=2,
         slice_axis=args.slice_axis,
     )
-    
-    # Compute configuration  
+
+    # Compute configuration
     accelerator = "cpu"
     if args.device == "auto":
         accelerator = "gpu" if torch.cuda.is_available() else "cpu"
     elif args.device in ["gpu", "cuda"]:
         accelerator = "gpu" if torch.cuda.is_available() else "cpu"
         if accelerator == "cpu" and args.device != "cpu":
-            logger.warning(f"Requested {args.device} but CUDA not available, using CPU")
-    
+            logger.warning(
+                f"Requested {args.device} but CUDA not available, using CPU"
+            )
+
     compute_config = ComputeConfig(
         devices=1,
         accelerator=accelerator,
         strategy="auto",
         precision="32",  # Use 32-bit for testing stability
-        num_workers=0,   # Disable multiprocessing for testing
+        num_workers=0,  # Disable multiprocessing for testing
     )
-    
+
     logger.info("✓ Configurations created successfully")
-    logger.info(f"  Data: {data_config.img_size}, axis={data_config.slice_axis}")
-    logger.info(f"  Model: {model_config.features} features, {model_config.activation} activation")
-    logger.info(f"  Compute: {compute_config.accelerator}, precision={compute_config.precision}")
-    
+    logger.info(
+        f"  Data: {data_config.img_size}, axis={data_config.slice_axis}"
+    )
+    logger.info(
+        f"  Model: {model_config.features} features, {model_config.activation} activation"
+    )
+    logger.info(
+        f"  Compute: {compute_config.accelerator}, precision={compute_config.precision}"
+    )
+
     return data_config, model_config, compute_config
 
 
-def test_dataset_loading(data_config: DataConfig, compute_config: ComputeConfig, annotation_type: str) -> Dict[str, Any]:
+def test_dataset_loading(
+    data_config: DataConfig, compute_config: ComputeConfig, annotation_type: str
+) -> dict[str, Any]:
     """Test dataset loading and return a sample batch.
-    
+
     Args:
         data_config: Data configuration
-        compute_config: Compute configuration  
+        compute_config: Compute configuration
         annotation_type: Annotation type to load
-        
+
     Returns:
         Dictionary containing sample batch data
-        
+
     Raises:
         SystemExit: If dataset loading fails
     """
     logger.info("Testing dataset loading...")
-    
+
     try:
         # Initialize DataModule
         datamodule = NiftiDataModule(
@@ -209,33 +223,39 @@ def test_dataset_loading(data_config: DataConfig, compute_config: ComputeConfig,
             cache_size=1,
             random_seed=42,
         )
-        
+
         # Setup data discovery
         logger.info("Running data discovery...")
         datamodule.setup()
-        
+
         # Get discovery summary
         summary = datamodule.get_discovery_summary()
         if summary:
-            logger.info(f"✓ Discovery completed:")
+            logger.info("✓ Discovery completed:")
             logger.info(f"  Total subjects: {summary['total_subjects']}")
-            logger.info(f"  Subjects with {annotation_type}: {summary['subjects_with_target_annotation']}")
-            logger.info(f"  Available annotations: {summary['annotation_types']}")
-        
-        if summary and summary['subjects_with_target_annotation'] == 0:
-            logger.error(f"No subjects found with annotation type '{annotation_type}'")
+            logger.info(
+                f"  Subjects with {annotation_type}: {summary['subjects_with_target_annotation']}"
+            )
+            logger.info(
+                f"  Available annotations: {summary['annotation_types']}"
+            )
+
+        if summary and summary["subjects_with_target_annotation"] == 0:
+            logger.error(
+                f"No subjects found with annotation type '{annotation_type}'"
+            )
             sys.exit(1)
-            
+
         # Get dataset info
         dataset_info = datamodule.get_dataset_info()
         logger.info("✓ Dataset splits created:")
         for split_name, info in dataset_info.items():
             logger.info(f"  {split_name}: {info['num_volumes']} volumes")
-            
+
         # Create data loader
         train_loader = datamodule.train_dataloader()
         logger.info(f"✓ Train DataLoader created: {len(train_loader)} batches")
-        
+
         # Get one sample batch
         logger.info("Loading sample batch...")
         for batch_idx, batch in enumerate(train_loader):
@@ -245,12 +265,12 @@ def test_dataset_loading(data_config: DataConfig, compute_config: ComputeConfig,
             logger.info(f"  Subject ID: {batch['subject_id']}")
             logger.info(f"  Annotation type: {batch['annotation_type']}")
             logger.info(f"  Number of slices: {batch['num_slices']}")
-            
+
             return batch
-            
+
         logger.error("No batches available in train loader")
         sys.exit(1)
-        
+
     except Exception as e:
         logger.exception("Failed to load dataset")
         logger.error(f"Dataset loading error: {e}")
@@ -259,23 +279,23 @@ def test_dataset_loading(data_config: DataConfig, compute_config: ComputeConfig,
 
 def test_model_initialization(model_config: ModelConfig) -> UNet2D:
     """Test UNet2D model initialization.
-    
+
     Args:
         model_config: Model configuration
-        
+
     Returns:
         Initialized UNet2D model
-        
+
     Raises:
         SystemExit: If model initialization fails
     """
     logger.info("Testing UNet2D model initialization...")
-    
+
     try:
         # Initialize model
         model = UNet2D(config=model_config)
         logger.info("✓ UNet2D model initialized successfully")
-        
+
         # Get model info
         model_info = model.get_model_info()
         logger.info("✓ Model architecture details:")
@@ -285,31 +305,33 @@ def test_model_initialization(model_config: ModelConfig) -> UNet2D:
         logger.info(f"  Features: {model_info['features']}")
         logger.info(f"  Activation: {model_info['activation']}")
         logger.info(f"  Spatial dims: {model_info['spatial_dims']}D")
-        
+
         return model
-        
+
     except Exception as e:
         logger.exception("Failed to initialize UNet2D model")
         logger.error(f"Model initialization error: {e}")
         sys.exit(1)
 
 
-def test_forward_pass(model: UNet2D, batch: Dict[str, Any], device: str) -> torch.Tensor:
+def test_forward_pass(
+    model: UNet2D, batch: dict[str, Any], device: str
+) -> torch.Tensor:
     """Test model forward pass with real batch data.
-    
+
     Args:
         model: UNet2D model instance
         batch: Sample batch from dataset
         device: Device to run inference on
-        
+
     Returns:
         Model output tensor
-        
+
     Raises:
         SystemExit: If forward pass fails
     """
     logger.info("Testing model forward pass...")
-    
+
     try:
         # Move model to device
         if device != "cpu" and torch.cuda.is_available():
@@ -317,46 +339,48 @@ def test_forward_pass(model: UNet2D, batch: Dict[str, Any], device: str) -> torc
             device_name = "GPU"
         else:
             device_name = "CPU"
-            
+
         model.eval()  # Set to evaluation mode
-        
+
         # Extract input tensor
         volume_tensor = batch["volume"]  # [N, C, H, W]
         logger.info(f"✓ Input tensor shape: {volume_tensor.shape}")
-        
+
         # Move to device
         if device != "cpu" and torch.cuda.is_available():
             volume_tensor = volume_tensor.cuda()
-            
+
         # Forward pass
         logger.info(f"Running forward pass on {device_name}...")
         with torch.no_grad():
             output = model(volume_tensor)
-            
+
         logger.info("✓ Forward pass completed successfully")
         logger.info(f"  Input shape: {volume_tensor.shape}")
         logger.info(f"  Output shape: {output.shape}")
         logger.info(f"  Device: {device_name}")
-        
+
         # Basic output validation
         expected_shape = volume_tensor.shape  # Should match input shape
         if output.shape != expected_shape:
-            logger.warning(f"Output shape {output.shape} differs from expected {expected_shape}")
+            logger.warning(
+                f"Output shape {output.shape} differs from expected {expected_shape}"
+            )
         else:
             logger.info("✓ Output shape matches expected format")
-            
+
         # Check output value ranges
         output_min = output.min().item()
         output_max = output.max().item()
         output_mean = output.mean().item()
-        
-        logger.info(f"✓ Output statistics:")
+
+        logger.info("✓ Output statistics:")
         logger.info(f"  Min: {output_min:.4f}")
-        logger.info(f"  Max: {output_max:.4f}") 
+        logger.info(f"  Max: {output_max:.4f}")
         logger.info(f"  Mean: {output_mean:.4f}")
-        
+
         return output
-        
+
     except Exception as e:
         logger.exception("Failed during model forward pass")
         logger.error(f"Forward pass error: {e}")
@@ -366,14 +390,14 @@ def test_forward_pass(model: UNet2D, batch: Dict[str, Any], device: str) -> torc
 def main() -> None:
     """Main test function."""
     setup_logging()
-    
+
     logger.info("=" * 60)
     logger.info("UNet2D Model Integration Test")
     logger.info("=" * 60)
-    
+
     # Parse arguments
     args = parse_arguments()
-    
+
     if args.verbose:
         logger.remove()
         logger.add(
@@ -381,35 +405,37 @@ def main() -> None:
             format="<green>{time:HH:mm:ss}</green> | <level>{level: <8}</level> | {message}",
             level="DEBUG",
         )
-    
-    logger.info(f"Test parameters:")
+
+    logger.info("Test parameters:")
     logger.info(f"  Data directory: {args.data_dir}")
     logger.info(f"  Annotation type: {args.annotation_type}")
     logger.info(f"  Device: {args.device}")
     logger.info(f"  Image size: {args.img_size}")
     logger.info(f"  Slice axis: {args.slice_axis}")
     logger.info("")
-    
+
     # Step 1: Validate data directory
     validate_data_directory(args.data_dir)
     logger.info("")
-    
+
     # Step 2: Create configurations
     data_config, model_config, compute_config = create_test_configurations(args)
     logger.info("")
-    
+
     # Step 3: Test dataset loading
-    batch = test_dataset_loading(data_config, compute_config, args.annotation_type)
+    batch = test_dataset_loading(
+        data_config, compute_config, args.annotation_type
+    )
     logger.info("")
-    
-    # Step 4: Test model initialization  
+
+    # Step 4: Test model initialization
     model = test_model_initialization(model_config)
     logger.info("")
-    
+
     # Step 5: Test forward pass
     output = test_forward_pass(model, batch, compute_config.accelerator)
     logger.info("")
-    
+
     # Final summary
     logger.info("=" * 60)
     logger.info("✓ ALL TESTS PASSED SUCCESSFULLY")
@@ -417,11 +443,17 @@ def main() -> None:
     logger.info("Integration test results:")
     logger.info(f"  ✓ Data directory validated: {args.data_dir}")
     logger.info(f"  ✓ Dataset loaded with {args.annotation_type} annotations")
-    logger.info(f"  ✓ UNet2D model initialized with {model_config.features} features")
-    logger.info(f"  ✓ Forward pass completed on {compute_config.accelerator.upper()}")
+    logger.info(
+        f"  ✓ UNet2D model initialized with {model_config.features} features"
+    )
+    logger.info(
+        f"  ✓ Forward pass completed on {compute_config.accelerator.upper()}"
+    )
     logger.info(f"  ✓ Output shape: {output.shape}")
     logger.info("")
-    logger.info("The UNet2D model is ready for training implementation (Task 10)")
+    logger.info(
+        "The UNet2D model is ready for training implementation (Task 10)"
+    )
 
 
 if __name__ == "__main__":

--- a/config_examples/README.md
+++ b/config_examples/README.md
@@ -97,7 +97,7 @@ Choose the configuration that best matches your hardware and use case.
 Common modifications:
 - **data_dir/annotation_dir**: Point to your data
 - **img_size**: Adjust for your image resolution needs
-- **batch_size**: Increase/decrease based on GPU memory
+- **inference_chunk_size**: Increase/decrease based on GPU memory during inference
 - **epochs**: Adjust training duration
 - **learning_rate**: Tune for your dataset
 
@@ -108,7 +108,7 @@ python -c "from niftilearn.config.loader import load_config; load_config('your_c
 
 ### 4. Use CLI overrides for quick testing
 ```bash
-niftilearn train -c config.yaml --epochs 5 --batch-size 2
+niftilearn train -c config.yaml --epochs 5 --inference-chunk-size 2
 ```
 
 ## Hardware-Specific Tips
@@ -125,13 +125,13 @@ niftilearn train -c config.yaml --epochs 5 --batch-size 2
 
 ### CPU Only
 - Use `accelerator: "cpu"` and `precision: "32"`
-- Reduce `batch_size` and `img_size` for reasonable performance
+- Reduce `inference_chunk_size` and `img_size` for reasonable performance
 - Consider fewer `num_workers`
 
 ## Common Issues
 
 ### Memory Errors
-- Reduce `batch_size` and/or `img_size`
+- Reduce `inference_chunk_size` and/or `img_size`
 - Use `precision: "16-mixed"` on compatible hardware
 - Decrease model `features`
 
@@ -143,7 +143,7 @@ niftilearn train -c config.yaml --epochs 5 --batch-size 2
 ### Configuration Validation Errors
 - Ensure `data.slice_axis == model.slice_axis`
 - Ensure `data.img_size == model.img_size`
-- Ensure `data.batch_size == training.batch_size`
+- Ensure `data.inference_chunk_size == training.inference_chunk_size`
 - Verify all splits sum to 1.0
 
 For more help, see the main documentation or create an issue on GitHub.

--- a/config_examples/complete_example.yaml
+++ b/config_examples/complete_example.yaml
@@ -17,7 +17,7 @@ data:
   # Slice extraction settings
   slice_axis: 2                        # Axis for slice extraction
                                        # 0 = axial (top-down), 1 = coronal (front-back), 2 = sagittal (left-right)
-  batch_size: 8                        # Slices per batch from the same volume
+  inference_chunk_size: 8              # Number of slices to process at once during inference
   img_size: [224, 224]                 # Target 2D slice size after resizing [Height, Width]
   
   # Volume preprocessing (applied before slice extraction)
@@ -78,7 +78,7 @@ model:
 # =============================================================================
 training:
   epochs: 100                          # Maximum training epochs
-  batch_size: 8                        # Must match data.batch_size exactly
+  inference_chunk_size: 8              # Must match data.inference_chunk_size exactly
   learning_rate: 1e-4                  # Initial learning rate (Adam/AdamW default)
   
   # Optimizer settings

--- a/config_examples/multi_gpu_production.yaml
+++ b/config_examples/multi_gpu_production.yaml
@@ -8,7 +8,7 @@ data:
   val_split: 0.15
   test_split: 0.05
   slice_axis: 2
-  batch_size: 16                       # Larger batch size for multi-GPU
+  inference_chunk_size: 16             # Larger chunk size for multi-GPU inference
   img_size: [256, 256]                 # Higher resolution
   target_spacing: [0.5, 0.5, 0.5]     # Higher resolution spacing
   target_size: [256, 256, 128]
@@ -34,7 +34,7 @@ model:
 
 training:
   epochs: 200                          # More epochs for production
-  batch_size: 16
+  inference_chunk_size: 16
   learning_rate: 2e-4                  # Adjusted for larger batch size
   optimizer: "AdamW"
   loss_function: "dicece"

--- a/config_examples/quick_start.yaml
+++ b/config_examples/quick_start.yaml
@@ -8,7 +8,7 @@ data:
   val_split: 0.2
   test_split: 0.1
   slice_axis: 2
-  batch_size: 4
+  inference_chunk_size: 4
   img_size: [128, 128]                 # Small size for quick training
   target_spacing: [1.0, 1.0, 1.0]
   target_size: [128, 128, 32]
@@ -34,7 +34,7 @@ model:
 
 training:
   epochs: 20                           # Quick training
-  batch_size: 4
+  inference_chunk_size: 4
   learning_rate: 1e-3
   optimizer: "Adam"
   loss_function: "dice"

--- a/docs/phase_plan.md
+++ b/docs/phase_plan.md
@@ -83,7 +83,7 @@ torchrun --nproc_per_node=2 -m niftilearn.cli.main --config example_config.yaml 
 niftilearn predict --model checkpoints/best.ckpt --input volume.nii.gz --output segmentation.nii.gz
 
 # Training with parameter overrides
-niftilearn --config example_config.yaml train --epochs 100 --batch-size 8 --learning-rate 1e-4
+niftilearn --config example_config.yaml train --epochs 100 --inference-chunk-size 8 --learning-rate 1e-4
 ```
 
 **Status**: Core implementation complete and ready for deployment. Optional enhancements and testing remain.

--- a/niftilearn/cli/main.py
+++ b/niftilearn/cli/main.py
@@ -78,10 +78,10 @@ def main(
     help="Number of training epochs (overrides config)",
 )
 @click.option(
-    "--batch-size",
-    "-b",
+    "--inference-chunk-size",
+    "-c",
     type=int,
-    help="Training batch size (overrides config)",
+    help="Inference chunk size for memory management (overrides config)",
 )
 @click.option(
     "--learning-rate",
@@ -93,7 +93,7 @@ def main(
 def train(
     ctx: click.Context,
     epochs: Optional[int],
-    batch_size: Optional[int],
+    inference_chunk_size: Optional[int],
     learning_rate: Optional[float],
 ) -> None:
     """Train a segmentation model on NIFTI volumes."""
@@ -111,49 +111,56 @@ def train(
     if epochs is not None:
         overrides["epochs"] = epochs
         logger.info(f"Overriding epochs: {epochs}")
-    if batch_size is not None:
-        overrides["batch_size"] = batch_size
-        logger.info(f"Overriding batch size: {batch_size}")
+    if inference_chunk_size is not None:
+        overrides["inference_chunk_size"] = inference_chunk_size
+        logger.info(f"Overriding inference chunk size: {inference_chunk_size}")
     if learning_rate is not None:
         overrides["learning_rate"] = learning_rate
         logger.info(f"Overriding learning rate: {learning_rate}")
 
     # Load configuration
+    import pytorch_lightning as pl
+    from pytorch_lightning.callbacks import (
+        EarlyStopping,
+        ModelCheckpoint,
+        RichProgressBar,
+    )
+
     from niftilearn.config.loader import load_config
     from niftilearn.data.datamodule import NiftiDataModule
     from niftilearn.models.unet import UNet2D
-    import pytorch_lightning as pl
-    from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping, RichProgressBar
-    
+
     try:
         config = load_config(config_path)
-        
+
         # Apply CLI overrides to training config
         if epochs is not None:
             config.training.epochs = epochs
-        if batch_size is not None:
-            config.training.batch_size = batch_size
-            config.data.batch_size = batch_size  # Keep data and training in sync
+        if inference_chunk_size is not None:
+            config.training.inference_chunk_size = inference_chunk_size
+            config.data.inference_chunk_size = (
+                inference_chunk_size  # Keep data and training in sync
+            )
         if learning_rate is not None:
             config.training.learning_rate = learning_rate
-            
+
         logger.info(f"Training configuration loaded: {config.training}")
-        
+
         # Create model and data module
         training_config_dict = {
-            'optimizer': config.training.optimizer,
-            'learning_rate': config.training.learning_rate,
-            'loss_function': config.training.loss_function,
-            'loss_kwargs': config.training.loss_kwargs,
-            'scheduler': config.training.scheduler,
-            'scheduler_kwargs': config.training.scheduler_kwargs,
+            "optimizer": config.training.optimizer,
+            "learning_rate": config.training.learning_rate,
+            "loss_function": config.training.loss_function,
+            "loss_kwargs": config.training.loss_kwargs,
+            "scheduler": config.training.scheduler,
+            "scheduler_kwargs": config.training.scheduler_kwargs,
         }
         model = UNet2D(config.model, training_config_dict)
         datamodule = NiftiDataModule(config.data, config.compute)
-        
+
         # Setup callbacks
         callbacks = []
-        
+
         # Model checkpointing
         checkpoint_callback = ModelCheckpoint(
             dirpath=config.output_dir / "checkpoints",
@@ -165,7 +172,7 @@ def train(
             verbose=True,
         )
         callbacks.append(checkpoint_callback)
-        
+
         # Early stopping
         if config.training.patience > 0:
             early_stopping = EarlyStopping(
@@ -176,11 +183,11 @@ def train(
                 verbose=True,
             )
             callbacks.append(early_stopping)
-        
+
         # Progress bar
         progress_bar = RichProgressBar()
         callbacks.append(progress_bar)
-        
+
         # Create trainer
         trainer = pl.Trainer(
             max_epochs=config.training.epochs,
@@ -193,25 +200,25 @@ def train(
             enable_model_summary=True,
             log_every_n_steps=50,
         )
-        
+
         # Create output directory
         config.output_dir.mkdir(parents=True, exist_ok=True)
         (config.output_dir / "checkpoints").mkdir(parents=True, exist_ok=True)
-        
+
         logger.info(f"Starting training for {config.training.epochs} epochs")
         logger.info(f"Model: {model.get_model_info()}")
-        
+
         # Start training
         trainer.fit(model, datamodule=datamodule)
-        
+
         # Log results
         best_checkpoint = checkpoint_callback.best_model_path
         best_score = checkpoint_callback.best_model_score
-        
+
         logger.info("Training completed successfully!")
         logger.info(f"Best checkpoint: {best_checkpoint}")
         logger.info(f"Best validation loss: {best_score}")
-        
+
     except Exception as e:
         logger.exception(f"Training failed: {e}")
         raise click.ClickException(f"Training failed: {e}")
@@ -257,78 +264,87 @@ def predict(
         logger.info(f"Using config: {config_path}")
 
     # Load model from checkpoint
-    from niftilearn.models.unet import UNet2D
-    from niftilearn.data.transforms import VolumeSliceExtractor
-    from niftilearn.utils.reconstruction import reconstruct_volume_from_predictions
-    import torch
     import nibabel as nib
-    import numpy as np
-    
+    import torch
+
+    from niftilearn.data.transforms import VolumeSliceExtractor
+    from niftilearn.models.unet import UNet2D
+    from niftilearn.utils.reconstruction import (
+        reconstruct_volume_from_predictions,
+    )
+
     try:
         # Load trained model
         logger.info(f"Loading model from checkpoint: {model}")
         trained_model = UNet2D.load_from_checkpoint(str(model))
         trained_model.eval()
-        
+
         # Load configuration if available
         slice_axis = 2  # Default
         img_size = [224, 224]  # Default
-        
+
         if config_path:
             from niftilearn.config.loader import load_config
+
             config = load_config(config_path)
             slice_axis = config.model.slice_axis
             img_size = config.model.img_size
-            logger.info(f"Using config slice_axis={slice_axis}, img_size={img_size}")
-        
+            logger.info(
+                f"Using config slice_axis={slice_axis}, img_size={img_size}"
+            )
+
         # Load input volume
         logger.info(f"Loading input volume: {input}")
         volume_img = nib.load(str(input))
         volume_data = volume_img.get_fdata()
-        
+
         logger.info(f"Input volume shape: {volume_data.shape}")
-        
+
         # Extract slices for processing
         slice_extractor = VolumeSliceExtractor(
             slice_axis=slice_axis,
             target_size=img_size,
             target_spacing=[1.0, 1.0, 1.0],  # Default spacing
         )
-        
+
         # Process volume to extract slices
         processed_slices = slice_extractor.extract_slices(volume_data)
-        
+
         # Convert to tensor and add batch dimension
         slice_tensor = torch.from_numpy(processed_slices).float()
         if slice_tensor.dim() == 3:
-            slice_tensor = slice_tensor.unsqueeze(1)  # Add channel dimension [N, C, H, W]
-        
+            slice_tensor = slice_tensor.unsqueeze(
+                1
+            )  # Add channel dimension [N, C, H, W]
+
         logger.info(f"Processing {slice_tensor.shape[0]} slices")
-        
+
         # Run inference
         predictions_list = []
         with torch.no_grad():
             # Process in batches to handle memory efficiently
-            batch_size = 8
+            batch_size = config.data.inference_chunk_size
             for i in range(0, slice_tensor.shape[0], batch_size):
-                batch = slice_tensor[i:i + batch_size]
+                batch = slice_tensor[i : i + batch_size]
                 batch_predictions = trained_model(batch)
-                
+
                 # Convert to probabilities
                 batch_probs = torch.sigmoid(batch_predictions)
                 predictions_list.append(batch_probs)
-        
+
         # Concatenate all predictions
         all_predictions = torch.cat(predictions_list, dim=0)
-        
+
         # Convert probabilities to binary masks (threshold at 0.5)
         binary_predictions = (all_predictions > 0.5).float()
-        
-        logger.info(f"Generated predictions with shape: {binary_predictions.shape}")
-        
+
+        logger.info(
+            f"Generated predictions with shape: {binary_predictions.shape}"
+        )
+
         # Create slice indices (assuming all slices in order)
         slice_indices = list(range(binary_predictions.shape[0]))
-        
+
         # Reconstruct 3D volume
         logger.info("Reconstructing 3D volume from slice predictions")
         output_volume_path = reconstruct_volume_from_predictions(
@@ -338,10 +354,10 @@ def predict(
             output_path=output,
             slice_axis=slice_axis,
         )
-        
-        logger.info(f"Prediction completed successfully!")
+
+        logger.info("Prediction completed successfully!")
         logger.info(f"Output segmentation saved: {output_volume_path}")
-        
+
     except Exception as e:
         logger.exception(f"Prediction failed: {e}")
         raise click.ClickException(f"Prediction failed: {e}")

--- a/niftilearn/config/loader.py
+++ b/niftilearn/config/loader.py
@@ -105,9 +105,13 @@ def apply_cli_overrides(config: Config, overrides: dict[str, Any]) -> Config:
         # Apply training overrides
         if "epochs" in overrides:
             config_dict["training"]["epochs"] = overrides["epochs"]
-        if "batch_size" in overrides:
-            config_dict["training"]["batch_size"] = overrides["batch_size"]
-            config_dict["data"]["batch_size"] = overrides["batch_size"]
+        if "inference_chunk_size" in overrides:
+            config_dict["training"]["inference_chunk_size"] = overrides[
+                "inference_chunk_size"
+            ]
+            config_dict["data"]["inference_chunk_size"] = overrides[
+                "inference_chunk_size"
+            ]
         if "learning_rate" in overrides:
             config_dict["training"]["learning_rate"] = overrides[
                 "learning_rate"

--- a/niftilearn/config/models.py
+++ b/niftilearn/config/models.py
@@ -27,7 +27,11 @@ class DataConfig(BaseModel):
     slice_axis: Literal[0, 1, 2] = Field(
         2, description="Axis for slice extraction"
     )
-    batch_size: int = Field(8, gt=0, description="Batch size for training")
+    inference_chunk_size: int = Field(
+        8,
+        gt=0,
+        description="Number of slices to process at once during inference",
+    )
     img_size: list[int] = Field(
         [224, 224], description="Target 2D slice size [H, W]"
     )
@@ -152,7 +156,11 @@ class TrainingConfig(BaseModel):
     """Training configuration."""
 
     epochs: int = Field(100, gt=0, description="Number of training epochs")
-    batch_size: int = Field(8, gt=0, description="Training batch size")
+    inference_chunk_size: int = Field(
+        8,
+        gt=0,
+        description="Number of slices to process at once during inference",
+    )
     learning_rate: float = Field(
         1e-4, gt=0, description="Initial learning rate"
     )
@@ -165,9 +173,9 @@ class TrainingConfig(BaseModel):
     loss_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Additional loss function parameters"
     )
-    scheduler: Optional[Literal["StepLR", "CosineAnnealingLR", "ReduceLROnPlateau"]] = Field(
-        None, description="Learning rate scheduler type"
-    )
+    scheduler: Optional[
+        Literal["StepLR", "CosineAnnealingLR", "ReduceLROnPlateau"]
+    ] = Field(None, description="Learning rate scheduler type")
     scheduler_kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Additional scheduler parameters"
     )
@@ -222,9 +230,9 @@ class Config(BaseModel):
                 f"model.img_size ({self.model.img_size})"
             )
 
-        # Ensure batch_size matches between data and training
-        if self.data.batch_size != self.training.batch_size:
+        # Ensure inference_chunk_size matches between data and training
+        if self.data.inference_chunk_size != self.training.inference_chunk_size:
             raise ValueError(
-                f"data.batch_size ({self.data.batch_size}) must match "
-                f"training.batch_size ({self.training.batch_size})"
+                f"data.inference_chunk_size ({self.data.inference_chunk_size}) must match "
+                f"training.inference_chunk_size ({self.training.inference_chunk_size})"
             )

--- a/niftilearn/core/logging.py
+++ b/niftilearn/core/logging.py
@@ -158,7 +158,7 @@ def log_config_summary(config) -> None:
     logger.info(f"Output directory: {config.output_dir}")
     logger.info(f"Slice axis: {config.data.slice_axis}")
     logger.info(f"Image size: {config.model.img_size}")
-    logger.info(f"Batch size: {config.training.batch_size}")
+    logger.info(f"Inference chunk size: {config.training.inference_chunk_size}")
     logger.info(f"Learning rate: {config.training.learning_rate}")
     logger.info(f"Epochs: {config.training.epochs}")
     logger.info(f"GPU devices: {config.compute.devices}")

--- a/niftilearn/models/unet.py
+++ b/niftilearn/models/unet.py
@@ -1,49 +1,50 @@
 """UNet2D model implementation using MONAI for medical image segmentation."""
 
-from typing import Any
+from typing import Any, Optional
 
 import pytorch_lightning as pl
 import torch
-import torch.nn as nn
 from loguru import logger
 from monai.networks.nets import UNet
 
-from niftilearn.config.models import Config, ModelConfig
+from niftilearn.config.models import ModelConfig
 
 
 class UNet2D(pl.LightningModule):
     """2D UNet model for slice-based medical image segmentation.
-    
+
     This Lightning module wraps MONAI's UNet architecture for 2D slice processing,
     designed to work with the volume-based batch processing pipeline where each
     batch contains all slices from a single volume.
-    
+
     The model expects input tensors of shape [N, C, H, W] where:
     - N: Number of slices in the volume
     - C: Number of input channels (typically 1 for grayscale medical images)
     - H, W: Height and width of each slice
-    
+
     Output tensors have the same shape [N, C, H, W] for segmentation masks.
     """
 
-    def __init__(self, config: ModelConfig, training_config: dict = None) -> None:
+    def __init__(
+        self, config: ModelConfig, training_config: Optional[dict] = None
+    ) -> None:
         """Initialize UNet2D model.
-        
+
         Args:
             config: Model configuration containing architecture parameters
             training_config: Training configuration dict (optional, for compatibility)
-            
+
         Raises:
             ValueError: If configuration parameters are invalid
         """
         super().__init__()
-        
+
         self.config = config
         self.training_config = training_config or {}
-        
+
         # Validate configuration
         self._validate_config()
-        
+
         # Create MONAI UNet with configuration parameters
         self.unet = UNet(
             spatial_dims=config.spatial_dims,
@@ -56,17 +57,17 @@ class UNet2D(pl.LightningModule):
             norm="BATCH",  # Batch normalization for stable training
             dropout=0.0,  # No dropout by default
         )
-        
+
         logger.info(f"UNet2D initialized with config: {config}")
         logger.info(
             f"Architecture: {config.spatial_dims}D, "
             f"channels: {config.in_channels}→{config.out_channels}, "
             f"features: {config.features}, activation: {config.activation}"
         )
-        
+
     def _validate_config(self) -> None:
         """Validate model configuration parameters.
-        
+
         Raises:
             ValueError: If configuration is invalid
         """
@@ -74,38 +75,38 @@ class UNet2D(pl.LightningModule):
             raise ValueError(
                 f"UNet2D only supports 2D processing, got spatial_dims={self.config.spatial_dims}"
             )
-            
+
         if self.config.in_channels <= 0:
             raise ValueError(
                 f"in_channels must be positive, got {self.config.in_channels}"
             )
-            
+
         if self.config.out_channels <= 0:
             raise ValueError(
                 f"out_channels must be positive, got {self.config.out_channels}"
             )
-            
+
         if len(self.config.features) < 2:
             raise ValueError(
                 f"features must have at least 2 levels, got {len(self.config.features)}"
             )
-            
+
         if len(self.config.img_size) != 2:
             raise ValueError(
                 f"img_size must be 2D [H, W], got {self.config.img_size}"
             )
-            
+
         logger.debug("Model configuration validation passed")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass through the UNet.
-        
+
         Args:
             x: Input tensor of shape [N, C, H, W]
-            
+
         Returns:
             Output segmentation tensor of shape [N, C, H, W]
-            
+
         Raises:
             ValueError: If input tensor shape is invalid
         """
@@ -114,14 +115,14 @@ class UNet2D(pl.LightningModule):
             raise ValueError(
                 f"Expected 4D input tensor [N, C, H, W], got {x.dim()}D tensor"
             )
-            
+
         batch_size, channels, height, width = x.shape
-        
+
         if channels != self.config.in_channels:
             raise ValueError(
                 f"Expected {self.config.in_channels} input channels, got {channels}"
             )
-            
+
         # Validate input dimensions match configuration
         expected_h, expected_w = self.config.img_size
         if height != expected_h or width != expected_w:
@@ -129,22 +130,24 @@ class UNet2D(pl.LightningModule):
                 f"Input size ({height}, {width}) differs from configured size "
                 f"({expected_h}, {expected_w}). Model may not perform optimally."
             )
-        
+
         # Forward pass through MONAI UNet
         output = self.unet(x)
-        
+
         # Validate output shape
         self._validate_output_shape(output, x.shape)
-        
+
         return output
-    
-    def _validate_output_shape(self, output: torch.Tensor, input_shape: torch.Size) -> None:
+
+    def _validate_output_shape(
+        self, output: torch.Tensor, input_shape: torch.Size
+    ) -> None:
         """Validate that output tensor has correct shape.
-        
+
         Args:
             output: Model output tensor
             input_shape: Original input tensor shape
-            
+
         Raises:
             RuntimeError: If output shape is unexpected
         """
@@ -154,45 +157,62 @@ class UNet2D(pl.LightningModule):
             input_shape[2],  # Same height
             input_shape[3],  # Same width
         )
-        
+
         if output.shape != expected_shape:
             raise RuntimeError(
                 f"Unexpected output shape {output.shape}, expected {expected_shape}"
             )
-            
+
         logger.debug(f"Output shape validation passed: {output.shape}")
 
     def configure_optimizers(self) -> Any:
         """Configure optimizer and learning rate scheduler.
-        
+
         Returns:
             Optimizer or dictionary containing optimizer and scheduler configuration
         """
-        from torch.optim import Adam, AdamW, SGD
-        from torch.optim.lr_scheduler import CosineAnnealingLR, ReduceLROnPlateau, StepLR
-        
+        from torch.optim import SGD, Adam, AdamW
+        from torch.optim.lr_scheduler import (
+            CosineAnnealingLR,
+            ReduceLROnPlateau,
+            StepLR,
+        )
+
         # Get training configuration from training_config or use defaults
-        optimizer_name = self.training_config.get('optimizer', 'AdamW')
-        learning_rate = self.training_config.get('learning_rate', 1e-4)
-        scheduler_name = self.training_config.get('scheduler', None)
-        scheduler_kwargs = self.training_config.get('scheduler_kwargs', {})
-        
+        optimizer_name = self.training_config.get("optimizer", "AdamW")
+        learning_rate = self.training_config.get("learning_rate", 1e-4)
+        scheduler_name = self.training_config.get("scheduler", None)
+        scheduler_kwargs = self.training_config.get("scheduler_kwargs", {})
+
         # Initialize optimizer
         if optimizer_name.lower() == "adam":
-            optimizer = Adam(self.parameters(), lr=learning_rate, weight_decay=1e-5)
+            optimizer = Adam(
+                self.parameters(), lr=learning_rate, weight_decay=1e-5
+            )
         elif optimizer_name.lower() == "adamw":
-            optimizer = AdamW(self.parameters(), lr=learning_rate, weight_decay=1e-2)
+            optimizer = AdamW(
+                self.parameters(), lr=learning_rate, weight_decay=1e-2
+            )
         elif optimizer_name.lower() == "sgd":
-            optimizer = SGD(self.parameters(), lr=learning_rate, momentum=0.9, weight_decay=1e-4)
+            optimizer = SGD(
+                self.parameters(),
+                lr=learning_rate,
+                momentum=0.9,
+                weight_decay=1e-4,
+            )
         else:
-            raise ValueError(f"Unknown optimizer '{optimizer_name}'. Available: 'Adam', 'AdamW', 'SGD'")
-        
-        logger.info(f"Configured {optimizer_name} optimizer with lr={learning_rate}")
-        
+            raise ValueError(
+                f"Unknown optimizer '{optimizer_name}'. Available: 'Adam', 'AdamW', 'SGD'"
+            )
+
+        logger.info(
+            f"Configured {optimizer_name} optimizer with lr={learning_rate}"
+        )
+
         # Return optimizer only if no scheduler is specified
         if not scheduler_name:
             return optimizer
-        
+
         # Configure scheduler
         scheduler_name_lower = scheduler_name.lower()
         if scheduler_name_lower == "steplr":
@@ -201,14 +221,20 @@ class UNet2D(pl.LightningModule):
                 step_size=scheduler_kwargs.get("step_size", 30),
                 gamma=scheduler_kwargs.get("gamma", 0.1),
             )
-            return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "interval": "epoch"}}
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {"scheduler": scheduler, "interval": "epoch"},
+            }
         elif scheduler_name_lower == "cosineannealinglr":
             scheduler = CosineAnnealingLR(
                 optimizer,
                 T_max=scheduler_kwargs.get("T_max", 100),
                 eta_min=scheduler_kwargs.get("eta_min", 1e-6),
             )
-            return {"optimizer": optimizer, "lr_scheduler": {"scheduler": scheduler, "interval": "epoch"}}
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {"scheduler": scheduler, "interval": "epoch"},
+            }
         elif scheduler_name_lower == "reducelronplateau":
             scheduler = ReduceLROnPlateau(
                 optimizer,
@@ -224,102 +250,130 @@ class UNet2D(pl.LightningModule):
                     "monitor": scheduler_kwargs.get("monitor", "val_loss"),
                     "interval": "epoch",
                     "frequency": 1,
-                }
+                },
             }
         else:
-            raise ValueError(f"Unknown scheduler '{scheduler_name}'. Available: 'StepLR', 'CosineAnnealingLR', 'ReduceLROnPlateau'")
+            raise ValueError(
+                f"Unknown scheduler '{scheduler_name}'. Available: 'StepLR', 'CosineAnnealingLR', 'ReduceLROnPlateau'"
+            )
 
     def training_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
         """Training step compatible with volume-based data pipeline.
-        
+
         Args:
             batch: Training batch with keys 'volume' and 'segmentation'
             batch_idx: Batch index
-            
+
         Returns:
             Training loss tensor
         """
         from niftilearn.training.losses import get_loss_function
         from niftilearn.training.metrics import SegmentationMetrics
-        
+
         # Initialize loss function if not already done
-        if not hasattr(self, 'criterion'):
-            loss_name = self.training_config.get('loss_function', 'dicece')
-            loss_kwargs = self.training_config.get('loss_kwargs', {})
+        if not hasattr(self, "criterion"):
+            loss_name = self.training_config.get("loss_function", "dicece")
+            loss_kwargs = self.training_config.get("loss_kwargs", {})
             self.criterion = get_loss_function(loss_name, **loss_kwargs)
-            
+
         # Initialize training metrics if not already done
-        if not hasattr(self, 'train_metrics'):
-            self.train_metrics = SegmentationMetrics(include_background=True, reduction="mean")
-        
+        if not hasattr(self, "train_metrics"):
+            self.train_metrics = SegmentationMetrics(
+                include_background=True, reduction="mean"
+            )
+
         # Extract data from batch (using correct keys from volume_batch_collate)
-        images = batch["volume"]        # [N, C, H, W] where N = num_slices
-        targets = batch["segmentation"] # [N, C, H, W]
-        
+        images = batch["volume"]  # [N, C, H, W] where N = num_slices
+        targets = batch["segmentation"]  # [N, C, H, W]
+
         # Forward pass
         predictions = self.forward(images)
-        
+
         # Calculate loss
         loss = self.criterion(predictions, targets)
-        
+
         # Update training metrics (convert predictions to probabilities for metrics)
         with torch.no_grad():
-            pred_probs = torch.sigmoid(predictions) if predictions.min() < 0 else predictions
+            pred_probs = (
+                torch.sigmoid(predictions)
+                if predictions.min() < 0
+                else predictions
+            )
             self.train_metrics.update(pred_probs, targets)
-        
+
         # Log training loss (Lightning 2.x pattern)
-        self.log("train_loss", loss, on_step=True, on_epoch=True, prog_bar=True, logger=True, sync_dist=True)
-        
+        self.log(
+            "train_loss",
+            loss,
+            on_step=True,
+            on_epoch=True,
+            prog_bar=True,
+            logger=True,
+            sync_dist=True,
+        )
+
         return loss
 
     def validation_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
         """Validation step compatible with volume-based data pipeline.
-        
+
         Args:
             batch: Validation batch with keys 'volume' and 'segmentation'
             batch_idx: Batch index
-            
+
         Returns:
             Validation loss tensor
         """
         from niftilearn.training.losses import get_loss_function
         from niftilearn.training.metrics import SegmentationMetrics
-        
+
         # Initialize loss function if not already done
-        if not hasattr(self, 'criterion'):
-            loss_name = self.training_config.get('loss_function', 'dicece')
-            loss_kwargs = self.training_config.get('loss_kwargs', {})
+        if not hasattr(self, "criterion"):
+            loss_name = self.training_config.get("loss_function", "dicece")
+            loss_kwargs = self.training_config.get("loss_kwargs", {})
             self.criterion = get_loss_function(loss_name, **loss_kwargs)
-            
+
         # Initialize validation metrics if not already done
-        if not hasattr(self, 'val_metrics'):
-            self.val_metrics = SegmentationMetrics(include_background=True, reduction="mean")
-        
+        if not hasattr(self, "val_metrics"):
+            self.val_metrics = SegmentationMetrics(
+                include_background=True, reduction="mean"
+            )
+
         # Extract data from batch (using correct keys from volume_batch_collate)
-        images = batch["volume"]        # [N, C, H, W]
-        targets = batch["segmentation"] # [N, C, H, W]
-        
+        images = batch["volume"]  # [N, C, H, W]
+        targets = batch["segmentation"]  # [N, C, H, W]
+
         # Forward pass
         predictions = self.forward(images)
-        
+
         # Calculate loss
         loss = self.criterion(predictions, targets)
-        
+
         # Update validation metrics (convert predictions to probabilities for metrics)
-        pred_probs = torch.sigmoid(predictions) if predictions.min() < 0 else predictions
+        pred_probs = (
+            torch.sigmoid(predictions) if predictions.min() < 0 else predictions
+        )
         self.val_metrics.update(pred_probs, targets)
-        
+
         # Log validation loss
-        self.log("val_loss", loss, on_step=False, on_epoch=True, prog_bar=True, logger=True, sync_dist=True)
-        
+        self.log(
+            "val_loss",
+            loss,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            logger=True,
+            sync_dist=True,
+        )
+
         return loss
 
     def on_train_epoch_end(self) -> None:
         """Called at the end of training epoch (Lightning 2.x)."""
-        if hasattr(self, 'train_metrics'):
+        if hasattr(self, "train_metrics"):
             # Compute and log training metrics
             train_metrics = self.train_metrics.compute()
-            
+
             for metric_name, metric_value in train_metrics.items():
                 # Handle both scalar and tensor metric values
                 if metric_value.numel() == 1:
@@ -327,23 +381,34 @@ class UNet2D(pl.LightningModule):
                 else:
                     # For multi-class metrics, log mean
                     metric_value = metric_value.mean().item()
-                
-                self.log(f"train_{metric_name}", metric_value, on_epoch=True, prog_bar=True, logger=True, sync_dist=True)
-            
+
+                self.log(
+                    f"train_{metric_name}",
+                    metric_value,
+                    on_epoch=True,
+                    prog_bar=True,
+                    logger=True,
+                    sync_dist=True,
+                )
+
             # Reset metrics for next epoch
             self.train_metrics.reset()
-        
+
         # Log learning rate if available
-        if hasattr(self, 'trainer') and self.trainer and self.trainer.optimizers:
-            current_lr = self.trainer.optimizers[0].param_groups[0]['lr']
+        if (
+            hasattr(self, "trainer")
+            and self.trainer
+            and self.trainer.optimizers
+        ):
+            current_lr = self.trainer.optimizers[0].param_groups[0]["lr"]
             self.log("learning_rate", current_lr, on_epoch=True, logger=True)
 
     def on_validation_epoch_end(self) -> None:
         """Called at the end of validation epoch (Lightning 2.x)."""
-        if hasattr(self, 'val_metrics'):
+        if hasattr(self, "val_metrics"):
             # Compute and log validation metrics
             val_metrics = self.val_metrics.compute()
-            
+
             for metric_name, metric_value in val_metrics.items():
                 # Handle both scalar and tensor metric values
                 if metric_value.numel() == 1:
@@ -351,33 +416,42 @@ class UNet2D(pl.LightningModule):
                 else:
                     # For multi-class metrics, log mean
                     metric_value = metric_value.mean().item()
-                
-                self.log(f"val_{metric_name}", metric_value, on_epoch=True, prog_bar=True, logger=True, sync_dist=True)
-            
+
+                self.log(
+                    f"val_{metric_name}",
+                    metric_value,
+                    on_epoch=True,
+                    prog_bar=True,
+                    logger=True,
+                    sync_dist=True,
+                )
+
             # Reset metrics for next epoch
             self.val_metrics.reset()
 
     def predict_step(self, batch: Any, batch_idx: int) -> torch.Tensor:
         """Prediction step for inference.
-        
+
         Args:
             batch: Batch containing 'volume' tensor
             batch_idx: Batch index
-            
+
         Returns:
             Model predictions as probabilities
         """
         images = batch["volume"]
         predictions = self.forward(images)
-        
+
         # Convert to probabilities
-        probabilities = torch.sigmoid(predictions) if predictions.min() < 0 else predictions
-        
+        probabilities = (
+            torch.sigmoid(predictions) if predictions.min() < 0 else predictions
+        )
+
         return probabilities
 
     def get_model_info(self) -> dict[str, Any]:
         """Get model architecture information.
-        
+
         Returns:
             Dictionary containing model configuration and basic info
         """

--- a/niftilearn/training/losses.py
+++ b/niftilearn/training/losses.py
@@ -4,7 +4,7 @@ This module provides a factory interface for MONAI's optimized loss functions
 designed for medical image segmentation tasks.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 import torch.nn as nn
 from loguru import logger
@@ -13,29 +13,29 @@ from monai.losses import DiceCELoss, DiceLoss, FocalLoss
 
 def get_loss_function(loss_name: str, **kwargs: Any) -> nn.Module:
     """Factory function to create MONAI loss functions by name.
-    
+
     This function provides a unified interface to create various MONAI loss
     functions commonly used for medical image segmentation.
-    
+
     Args:
         loss_name: Name of the loss function ('dice', 'focal', 'dicece')
         **kwargs: Additional arguments passed to the MONAI loss function
-        
+
     Returns:
         Configured MONAI loss function instance
-        
+
     Raises:
         ValueError: If loss_name is not recognized
     """
     # Registry of available MONAI loss functions
-    loss_registry: Dict[str, type[nn.Module]] = {
+    loss_registry: dict[str, type[nn.Module]] = {
         "dice": DiceLoss,
         "focal": FocalLoss,
         "dicece": DiceCELoss,
         "dice_ce": DiceCELoss,  # Alternative name
         "dicecross": DiceCELoss,  # Another alternative
     }
-    
+
     loss_name_lower = loss_name.lower()
     if loss_name_lower not in loss_registry:
         available_losses = list(loss_registry.keys())
@@ -43,9 +43,9 @@ def get_loss_function(loss_name: str, **kwargs: Any) -> nn.Module:
             f"Unknown loss function '{loss_name}'. "
             f"Available options: {available_losses}"
         )
-    
+
     loss_class = loss_registry[loss_name_lower]
-    
+
     # Apply default parameters for common use cases
     if loss_name_lower == "dice":
         # MONAI DiceLoss defaults: include_background=True, to_onehot_y=False, sigmoid=False
@@ -60,22 +60,28 @@ def get_loss_function(loss_name: str, **kwargs: Any) -> nn.Module:
         loss_instance = loss_class(**default_kwargs)
     elif loss_name_lower in ["dicece", "dice_ce", "dicecross"]:
         # MONAI DiceCELoss defaults: include_background=True, to_onehot_y=False, sigmoid=False
-        default_kwargs = {"include_background": True, "sigmoid": True, "softmax": False}
+        default_kwargs = {
+            "include_background": True,
+            "sigmoid": True,
+            "softmax": False,
+        }
         default_kwargs.update(kwargs)
         loss_instance = loss_class(**default_kwargs)
     else:
         loss_instance = loss_class(**kwargs)
-    
-    logger.info(f"Created MONAI {loss_class.__name__} with parameters: {kwargs}")
+
+    logger.info(
+        f"Created MONAI {loss_class.__name__} with parameters: {kwargs}"
+    )
     return loss_instance
 
 
-def get_default_loss_config(loss_name: str) -> Dict[str, Any]:
+def get_default_loss_config(loss_name: str) -> dict[str, Any]:
     """Get default configuration for a specific loss function.
-    
+
     Args:
         loss_name: Name of the loss function
-        
+
     Returns:
         Dictionary of default parameters for the loss function
     """
@@ -100,9 +106,9 @@ def get_default_loss_config(loss_name: str) -> Dict[str, Any]:
             "lambda_ce": 1.0,
         },
     }
-    
+
     loss_name_lower = loss_name.lower()
     if loss_name_lower in ["dice_ce", "dicecross"]:
         loss_name_lower = "dicece"
-        
+
     return defaults.get(loss_name_lower, {})

--- a/niftilearn/training/metrics.py
+++ b/niftilearn/training/metrics.py
@@ -4,7 +4,7 @@ This module provides a factory interface for MONAI's optimized metrics
 designed for medical image segmentation evaluation.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Union
 
 import torch
 from loguru import logger
@@ -13,7 +13,7 @@ from monai.metrics import DiceMetric, MeanIoU
 
 class SegmentationMetrics:
     """Combined segmentation metrics using MONAI's implementations.
-    
+
     This class provides a unified interface for multiple MONAI metrics
     commonly used in segmentation evaluation.
     """
@@ -25,7 +25,7 @@ class SegmentationMetrics:
         get_not_nans: bool = False,
     ) -> None:
         """Initialize segmentation metrics.
-        
+
         Args:
             include_background: Whether to include background class in calculations
             reduction: Reduction method ('mean', 'sum', 'mean_batch', 'sum_batch', 'none')
@@ -34,20 +34,20 @@ class SegmentationMetrics:
         self.include_background = include_background
         self.reduction = reduction
         self.get_not_nans = get_not_nans
-        
+
         # Initialize MONAI metrics
         self.dice_metric = DiceMetric(
             include_background=include_background,
             reduction=reduction,
             get_not_nans=get_not_nans,
         )
-        
+
         self.iou_metric = MeanIoU(
             include_background=include_background,
             reduction=reduction,
             get_not_nans=get_not_nans,
         )
-        
+
         logger.debug(
             f"SegmentationMetrics initialized with include_background={include_background}, "
             f"reduction={reduction}, get_not_nans={get_not_nans}"
@@ -60,7 +60,7 @@ class SegmentationMetrics:
 
     def update(self, y_pred: torch.Tensor, y: torch.Tensor) -> None:
         """Update all metrics with batch predictions and targets.
-        
+
         Args:
             y_pred: Predictions tensor [N, C, H, W] or [N, H, W]
             y: Ground truth tensor [N, C, H, W] or [N, H, W]
@@ -68,65 +68,67 @@ class SegmentationMetrics:
         # Ensure predictions are probabilities (apply sigmoid if needed)
         if y_pred.min() < 0 or y_pred.max() > 1:
             y_pred = torch.sigmoid(y_pred)
-            
+
         # MONAI metrics expect [N, C, H, W] format
         if y_pred.dim() == 3:
             y_pred = y_pred.unsqueeze(1)
             y = y.unsqueeze(1)
-            
+
         self.dice_metric(y_pred, y)
         self.iou_metric(y_pred, y)
 
-    def compute(self) -> Dict[str, torch.Tensor]:
+    def compute(self) -> dict[str, torch.Tensor]:
         """Compute all accumulated metrics.
-        
+
         Returns:
             Dictionary containing computed metrics
         """
         dice_score = self.dice_metric.aggregate()
         iou_score = self.iou_metric.aggregate()
-        
+
         return {
             "dice": dice_score,
             "iou": iou_score,
         }
 
-    def compute_batch(self, y_pred: torch.Tensor, y: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def compute_batch(
+        self, y_pred: torch.Tensor, y: torch.Tensor
+    ) -> dict[str, torch.Tensor]:
         """Compute metrics for a single batch without accumulation.
-        
+
         Args:
             y_pred: Predictions tensor [N, C, H, W] or [N, H, W]
             y: Ground truth tensor [N, C, H, W] or [N, H, W]
-            
+
         Returns:
             Dictionary containing batch metrics
         """
         # Ensure predictions are probabilities (apply sigmoid if needed)
         if y_pred.min() < 0 or y_pred.max() > 1:
             y_pred = torch.sigmoid(y_pred)
-            
+
         # MONAI metrics expect [N, C, H, W] format
         if y_pred.dim() == 3:
             y_pred = y_pred.unsqueeze(1)
             y = y.unsqueeze(1)
-        
+
         # Create temporary metric instances for batch computation
         temp_dice = DiceMetric(
             include_background=self.include_background,
             reduction="none",  # Get per-sample results
             get_not_nans=self.get_not_nans,
         )
-        
+
         temp_iou = MeanIoU(
             include_background=self.include_background,
             reduction="none",  # Get per-sample results
             get_not_nans=self.get_not_nans,
         )
-        
+
         # Compute batch metrics
         dice_batch = temp_dice(y_pred, y)
         iou_batch = temp_iou(y_pred, y)
-        
+
         return {
             "dice": dice_batch,
             "iou": iou_batch,
@@ -135,24 +137,24 @@ class SegmentationMetrics:
 
 def get_metric(metric_name: str, **kwargs: Any) -> Union[DiceMetric, MeanIoU]:
     """Factory function to create MONAI metrics by name.
-    
+
     Args:
         metric_name: Name of the metric ('dice', 'iou')
         **kwargs: Additional arguments passed to the MONAI metric
-        
+
     Returns:
         Configured MONAI metric instance
-        
+
     Raises:
         ValueError: If metric_name is not recognized
     """
-    metric_registry: Dict[str, type] = {
+    metric_registry: dict[str, type] = {
         "dice": DiceMetric,
         "iou": MeanIoU,
         "mean_iou": MeanIoU,  # Alternative name
-        "jaccard": MeanIoU,   # IoU is also known as Jaccard index
+        "jaccard": MeanIoU,  # IoU is also known as Jaccard index
     }
-    
+
     metric_name_lower = metric_name.lower()
     if metric_name_lower not in metric_registry:
         available_metrics = list(metric_registry.keys())
@@ -160,9 +162,9 @@ def get_metric(metric_name: str, **kwargs: Any) -> Union[DiceMetric, MeanIoU]:
             f"Unknown metric '{metric_name}'. "
             f"Available options: {available_metrics}"
         )
-    
+
     metric_class = metric_registry[metric_name_lower]
-    
+
     # Apply default parameters for binary segmentation
     default_kwargs = {
         "include_background": True,
@@ -170,19 +172,21 @@ def get_metric(metric_name: str, **kwargs: Any) -> Union[DiceMetric, MeanIoU]:
         "get_not_nans": False,
     }
     default_kwargs.update(kwargs)
-    
+
     metric_instance = metric_class(**default_kwargs)
-    
-    logger.info(f"Created MONAI {metric_class.__name__} with parameters: {kwargs}")
+
+    logger.info(
+        f"Created MONAI {metric_class.__name__} with parameters: {kwargs}"
+    )
     return metric_instance
 
 
-def get_default_metric_config(metric_name: str) -> Dict[str, Any]:
+def get_default_metric_config(metric_name: str) -> dict[str, Any]:
     """Get default configuration for a specific metric.
-    
+
     Args:
         metric_name: Name of the metric
-        
+
     Returns:
         Dictionary of default parameters for the metric
     """
@@ -200,9 +204,9 @@ def get_default_metric_config(metric_name: str) -> Dict[str, Any]:
             "ignore_empty": True,
         },
     }
-    
+
     metric_name_lower = metric_name.lower()
     if metric_name_lower in ["mean_iou", "jaccard"]:
         metric_name_lower = "iou"
-        
+
     return defaults.get(metric_name_lower, {})

--- a/niftilearn/utils/reconstruction.py
+++ b/niftilearn/utils/reconstruction.py
@@ -15,7 +15,7 @@ from loguru import logger
 
 class VolumeReconstructor:
     """Reconstructs 3D volumes from 2D slice predictions.
-    
+
     This class handles the reassembly of 2D slice predictions back into 3D volumes
     while preserving the original NIFTI metadata, spacing, and orientation.
     """
@@ -26,15 +26,17 @@ class VolumeReconstructor:
         preserve_metadata: bool = True,
     ) -> None:
         """Initialize volume reconstructor.
-        
+
         Args:
             slice_axis: Axis along which slices were extracted (0=axial, 1=coronal, 2=sagittal)
             preserve_metadata: Whether to preserve original NIFTI metadata
         """
         self.slice_axis = slice_axis
         self.preserve_metadata = preserve_metadata
-        
-        logger.debug(f"VolumeReconstructor initialized with slice_axis={slice_axis}")
+
+        logger.debug(
+            f"VolumeReconstructor initialized with slice_axis={slice_axis}"
+        )
 
     def reconstruct_volume(
         self,
@@ -44,16 +46,16 @@ class VolumeReconstructor:
         target_shape: Optional[tuple[int, int, int]] = None,
     ) -> tuple[np.ndarray, nib.Nifti1Image]:
         """Reconstruct 3D volume from 2D slice predictions.
-        
+
         Args:
             slice_predictions: Tensor of slice predictions [N, C, H, W]
             slice_indices: Original slice indices in the volume
             reference_volume_path: Path to reference volume for metadata
             target_shape: Target 3D shape (if None, inferred from reference)
-            
+
         Returns:
             Tuple of (reconstructed_array, nifti_image)
-            
+
         Raises:
             ValueError: If slice predictions and indices don't match
             FileNotFoundError: If reference volume doesn't exist
@@ -64,47 +66,61 @@ class VolumeReconstructor:
                 f"Number of predictions ({len(slice_predictions)}) doesn't match "
                 f"number of indices ({len(slice_indices)})"
             )
-            
+
         if not Path(reference_volume_path).exists():
-            raise FileNotFoundError(f"Reference volume not found: {reference_volume_path}")
-        
+            raise FileNotFoundError(
+                f"Reference volume not found: {reference_volume_path}"
+            )
+
         # Load reference volume for metadata
         reference_img = nib.load(reference_volume_path)
         reference_data = reference_img.get_fdata()
-        
+
         # Determine target shape
         if target_shape is None:
             target_shape = reference_data.shape
-        
-        logger.info(f"Reconstructing volume with shape {target_shape} from {len(slice_predictions)} slices")
-        
+
+        logger.info(
+            f"Reconstructing volume with shape {target_shape} from {len(slice_predictions)} slices"
+        )
+
         # Convert predictions to numpy
         predictions_np = slice_predictions.cpu().numpy()
-        
+
         # Handle channel dimension (assume single channel output)
         if predictions_np.ndim == 4 and predictions_np.shape[1] == 1:
-            predictions_np = predictions_np.squeeze(1)  # Remove channel dimension
+            predictions_np = predictions_np.squeeze(
+                1
+            )  # Remove channel dimension
         elif predictions_np.ndim == 4:
-            logger.warning(f"Multi-channel predictions ({predictions_np.shape[1]} channels), using first channel")
+            logger.warning(
+                f"Multi-channel predictions ({predictions_np.shape[1]} channels), using first channel"
+            )
             predictions_np = predictions_np[:, 0, :, :]
-        
+
         # Initialize output volume
-        reconstructed_volume = np.zeros(target_shape, dtype=predictions_np.dtype)
-        
+        reconstructed_volume = np.zeros(
+            target_shape, dtype=predictions_np.dtype
+        )
+
         # Place slices in correct positions
         for i, slice_idx in enumerate(slice_indices):
             if slice_idx >= target_shape[self.slice_axis]:
-                logger.warning(f"Slice index {slice_idx} exceeds volume size {target_shape[self.slice_axis]}")
+                logger.warning(
+                    f"Slice index {slice_idx} exceeds volume size {target_shape[self.slice_axis]}"
+                )
                 continue
-                
+
             # Get prediction slice
             pred_slice = predictions_np[i]
-            
+
             # Resize if necessary to match target shape
-            target_slice_shape = self._get_slice_shape(target_shape, self.slice_axis)
+            target_slice_shape = self._get_slice_shape(
+                target_shape, self.slice_axis
+            )
             if pred_slice.shape != target_slice_shape:
                 pred_slice = self._resize_slice(pred_slice, target_slice_shape)
-            
+
             # Place slice in volume
             if self.slice_axis == 0:
                 reconstructed_volume[slice_idx, :, :] = pred_slice
@@ -112,30 +128,34 @@ class VolumeReconstructor:
                 reconstructed_volume[:, slice_idx, :] = pred_slice
             elif self.slice_axis == 2:
                 reconstructed_volume[:, :, slice_idx] = pred_slice
-        
+
         # Create NIFTI image with preserved metadata
         if self.preserve_metadata:
             reconstructed_img = nib.Nifti1Image(
                 reconstructed_volume,
                 reference_img.affine,
-                reference_img.header.copy()
+                reference_img.header.copy(),
             )
             # Update header for segmentation mask
             reconstructed_img.header.set_data_dtype(reconstructed_volume.dtype)
         else:
             # Create basic NIFTI image
             reconstructed_img = nib.Nifti1Image(reconstructed_volume, np.eye(4))
-        
-        logger.info(f"Volume reconstruction completed: shape={reconstructed_volume.shape}")
+
+        logger.info(
+            f"Volume reconstruction completed: shape={reconstructed_volume.shape}"
+        )
         return reconstructed_volume, reconstructed_img
 
-    def _get_slice_shape(self, volume_shape: tuple[int, int, int], axis: int) -> tuple[int, int]:
+    def _get_slice_shape(
+        self, volume_shape: tuple[int, int, int], axis: int
+    ) -> tuple[int, int]:
         """Get the 2D shape of a slice from a 3D volume shape.
-        
+
         Args:
             volume_shape: 3D volume shape (H, W, D)
             axis: Slice axis
-            
+
         Returns:
             2D slice shape
         """
@@ -148,78 +168,84 @@ class VolumeReconstructor:
         else:
             raise ValueError(f"Invalid slice axis: {axis}")
 
-    def _resize_slice(self, slice_data: np.ndarray, target_shape: tuple[int, int]) -> np.ndarray:
+    def _resize_slice(
+        self, slice_data: np.ndarray, target_shape: tuple[int, int]
+    ) -> np.ndarray:
         """Resize a 2D slice to target shape using interpolation.
-        
+
         Args:
             slice_data: 2D slice data
             target_shape: Target 2D shape
-            
+
         Returns:
             Resized slice data
         """
         # Use scipy for resizing if available, otherwise use simple nearest neighbor
         try:
             from scipy.ndimage import zoom
-            
+
             # Calculate zoom factors
             zoom_factors = (
                 target_shape[0] / slice_data.shape[0],
                 target_shape[1] / slice_data.shape[1],
             )
-            
+
             # Use nearest neighbor for segmentation masks
             resized_slice = zoom(slice_data, zoom_factors, order=0)
-            
+
             # Ensure exact target shape (zoom might have small rounding errors)
             if resized_slice.shape != target_shape:
                 # Crop or pad as needed
                 resized_slice = self._crop_or_pad(resized_slice, target_shape)
-                
+
             return resized_slice
-            
+
         except ImportError:
             logger.warning("SciPy not available, using simple resizing")
             # Simple nearest neighbor resizing
             return self._simple_resize(slice_data, target_shape)
 
-    def _crop_or_pad(self, data: np.ndarray, target_shape: tuple[int, int]) -> np.ndarray:
+    def _crop_or_pad(
+        self, data: np.ndarray, target_shape: tuple[int, int]
+    ) -> np.ndarray:
         """Crop or pad data to match target shape.
-        
+
         Args:
             data: Input 2D array
             target_shape: Target shape
-            
+
         Returns:
             Cropped or padded array
         """
         current_shape = data.shape
         result = np.zeros(target_shape, dtype=data.dtype)
-        
+
         # Calculate crop/pad regions
         h_min = min(current_shape[0], target_shape[0])
         w_min = min(current_shape[1], target_shape[1])
-        
+
         # Copy data
         result[:h_min, :w_min] = data[:h_min, :w_min]
-        
+
         return result
 
-    def _simple_resize(self, data: np.ndarray, target_shape: tuple[int, int]) -> np.ndarray:
+    def _simple_resize(
+        self, data: np.ndarray, target_shape: tuple[int, int]
+    ) -> np.ndarray:
         """Simple nearest neighbor resizing without external dependencies.
-        
+
         Args:
             data: Input 2D array
             target_shape: Target shape
-            
+
         Returns:
             Resized array
         """
         h_ratio = data.shape[0] / target_shape[0]
         w_ratio = data.shape[1] / target_shape[1]
-        
+
         result = np.zeros(target_shape, dtype=data.dtype)
-        
+
         for i in range(target_shape[0]):
             for j in range(target_shape[1]):
                 src_i = int(i * h_ratio)
@@ -227,7 +253,7 @@ class VolumeReconstructor:
                 src_i = min(src_i, data.shape[0] - 1)
                 src_j = min(src_j, data.shape[1] - 1)
                 result[i, j] = data[src_i, src_j]
-        
+
         return result
 
     def save_volume(
@@ -236,17 +262,17 @@ class VolumeReconstructor:
         output_path: Union[str, Path],
     ) -> None:
         """Save reconstructed volume to disk.
-        
+
         Args:
             nifti_image: NIFTI image with metadata
             output_path: Output file path
         """
         output_path = Path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         # Save NIFTI image
         nib.save(nifti_image, str(output_path))
-        
+
         logger.info(f"Reconstructed volume saved: {output_path}")
 
 
@@ -258,32 +284,32 @@ def reconstruct_volume_from_predictions(
     slice_axis: int = 2,
 ) -> Path:
     """Convenience function to reconstruct and save a volume from predictions.
-    
+
     Args:
         predictions: Tensor of slice predictions [N, C, H, W]
         slice_indices: Original slice indices
         reference_volume: Path to reference volume for metadata
         output_path: Output file path
         slice_axis: Slice extraction axis
-        
+
     Returns:
         Path to saved volume
-        
+
     Raises:
         ValueError: If inputs are invalid
         FileNotFoundError: If reference volume doesn't exist
     """
     reconstructor = VolumeReconstructor(slice_axis=slice_axis)
-    
+
     # Reconstruct volume
     volume_data, nifti_image = reconstructor.reconstruct_volume(
         slice_predictions=predictions,
         slice_indices=slice_indices,
         reference_volume_path=reference_volume,
     )
-    
+
     # Save volume
     output_path = Path(output_path)
     reconstructor.save_volume(nifti_image, output_path)
-    
+
     return output_path


### PR DESCRIPTION
## Summary
- Renamed misleading `batch_size` parameter to `inference_chunk_size` throughout codebase
- Updated CLI parameter from `--batch-size` to `--inference-chunk-size`
- Fixed all configuration files, documentation, and examples

## Problem
The `batch_size` parameter was confusing because it's not used for actual DataLoader batching (which is hardcoded to 1 volume per batch). It's only used for chunking slices during inference for memory management.

## Solution
Renamed to `inference_chunk_size` which accurately describes its purpose: controlling how many slices are processed at once during inference to manage GPU memory usage.