### PR TITLE
Add annotation_type configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ from niftilearn.utils.reconstruction import reconstruct_volume_from_predictions
 # Load configuration and create components
 config = load_config("example_config.yaml")
 model = UNet2D(config.model)
-datamodule = NiftiDataModule(config.data)
+datamodule = NiftiDataModule(config.data, config.compute)
 
 # Training with Lightning
 import pytorch_lightning as pl
@@ -130,6 +130,7 @@ Use YAML configuration files for reproducible experiments. See `example_config.y
 data:
   data_dir: "./data/volumes"
   annotation_dir: "./data/annotations"
+  annotation_type: "ART"                   # Target annotation: "ART", "RA", "S_FAT"
   train_split: 0.7
   val_split: 0.2
   test_split: 0.1

--- a/bin/example_datamodule_usage.py
+++ b/bin/example_datamodule_usage.py
@@ -20,6 +20,7 @@ def main():
         annotation_dir=Path(
             "/path/to/annotations"
         ),  # Not used in current implementation
+        annotation_type="ART",  # Target artery annotations
         train_split=0.7,
         val_split=0.2,
         test_split=0.1,
@@ -42,7 +43,6 @@ def main():
     datamodule = NiftiDataModule(
         data_config=data_config,
         compute_config=compute_config,
-        annotation_type="ART",  # Target artery annotations
         enable_caching=True,  # Cache volumes for faster loading
         cache_size=10,  # Cache up to 10 volumes per dataset split
         random_seed=42,  # For reproducible splits

--- a/bin/test_unet2d_integration.py
+++ b/bin/test_unet2d_integration.py
@@ -138,6 +138,7 @@ def create_test_configurations(
     data_config = DataConfig(
         data_dir=args.data_dir,
         annotation_dir=args.data_dir,  # Same directory for annotations
+        annotation_type=args.annotation_type,  # Use annotation type from args
         train_split=0.7,
         val_split=0.2,
         test_split=0.1,
@@ -196,14 +197,13 @@ def create_test_configurations(
 
 
 def test_dataset_loading(
-    data_config: DataConfig, compute_config: ComputeConfig, annotation_type: str
+    data_config: DataConfig, compute_config: ComputeConfig
 ) -> dict[str, Any]:
     """Test dataset loading and return a sample batch.
 
     Args:
-        data_config: Data configuration
+        data_config: Data configuration (includes annotation_type)
         compute_config: Compute configuration
-        annotation_type: Annotation type to load
 
     Returns:
         Dictionary containing sample batch data
@@ -218,7 +218,6 @@ def test_dataset_loading(
         datamodule = NiftiDataModule(
             data_config=data_config,
             compute_config=compute_config,
-            annotation_type=annotation_type,
             enable_caching=False,  # Disable caching for testing
             cache_size=1,
             random_seed=42,
@@ -234,7 +233,7 @@ def test_dataset_loading(
             logger.info("✓ Discovery completed:")
             logger.info(f"  Total subjects: {summary['total_subjects']}")
             logger.info(
-                f"  Subjects with {annotation_type}: {summary['subjects_with_target_annotation']}"
+                f"  Subjects with {data_config.annotation_type}: {summary['subjects_with_target_annotation']}"
             )
             logger.info(
                 f"  Available annotations: {summary['annotation_types']}"
@@ -242,7 +241,7 @@ def test_dataset_loading(
 
         if summary and summary["subjects_with_target_annotation"] == 0:
             logger.error(
-                f"No subjects found with annotation type '{annotation_type}'"
+                f"No subjects found with annotation type '{data_config.annotation_type}'"
             )
             sys.exit(1)
 
@@ -423,9 +422,7 @@ def main() -> None:
     logger.info("")
 
     # Step 3: Test dataset loading
-    batch = test_dataset_loading(
-        data_config, compute_config, args.annotation_type
-    )
+    batch = test_dataset_loading(data_config, compute_config)
     logger.info("")
 
     # Step 4: Test model initialization
@@ -442,7 +439,9 @@ def main() -> None:
     logger.info("=" * 60)
     logger.info("Integration test results:")
     logger.info(f"  ✓ Data directory validated: {args.data_dir}")
-    logger.info(f"  ✓ Dataset loaded with {args.annotation_type} annotations")
+    logger.info(
+        f"  ✓ Dataset loaded with {data_config.annotation_type} annotations"
+    )
     logger.info(
         f"  ✓ UNet2D model initialized with {model_config.features} features"
     )

--- a/config_examples/complete_example.yaml
+++ b/config_examples/complete_example.yaml
@@ -9,6 +9,9 @@ data:
   data_dir: "./data/volumes"           # Directory containing NIFTI volumes
   annotation_dir: "./data/annotations" # Directory containing segmentation masks
   
+  # Annotation type
+  annotation_type: "ART"               # Target annotation type: "ART", "RA", "S_FAT"
+  
   # Dataset splits (must sum to 1.0)
   train_split: 0.7                     # 70% for training
   val_split: 0.2                       # 20% for validation  

--- a/config_examples/multi_gpu_production.yaml
+++ b/config_examples/multi_gpu_production.yaml
@@ -4,6 +4,7 @@
 data:
   data_dir: "./data/volumes"
   annotation_dir: "./data/annotations"
+  annotation_type: "ART"               # Target annotation type: "ART", "RA", "S_FAT"
   train_split: 0.8
   val_split: 0.15
   test_split: 0.05

--- a/config_examples/quick_start.yaml
+++ b/config_examples/quick_start.yaml
@@ -4,6 +4,7 @@
 data:
   data_dir: "./data/volumes"
   annotation_dir: "./data/annotations"
+  annotation_type: "ART"               # Target annotation type: "ART", "RA", "S_FAT"
   train_split: 0.7
   val_split: 0.2
   test_split: 0.1

--- a/niftilearn/cli/main.py
+++ b/niftilearn/cli/main.py
@@ -89,12 +89,19 @@ def main(
     type=float,
     help="Learning rate (overrides config)",
 )
+@click.option(
+    "--annotation-type",
+    "-a",
+    type=click.Choice(["ART", "RA", "S_FAT"]),
+    help="Annotation type to train on (overrides config)",
+)
 @click.pass_context
 def train(
     ctx: click.Context,
     epochs: Optional[int],
     inference_chunk_size: Optional[int],
     learning_rate: Optional[float],
+    annotation_type: Optional[str],
 ) -> None:
     """Train a segmentation model on NIFTI volumes."""
     config_path = ctx.obj.get("config_path")
@@ -117,6 +124,9 @@ def train(
     if learning_rate is not None:
         overrides["learning_rate"] = learning_rate
         logger.info(f"Overriding learning rate: {learning_rate}")
+    if annotation_type is not None:
+        overrides["annotation_type"] = annotation_type
+        logger.info(f"Overriding annotation type: {annotation_type}")
 
     # Load configuration
     import pytorch_lightning as pl
@@ -143,6 +153,8 @@ def train(
             )
         if learning_rate is not None:
             config.training.learning_rate = learning_rate
+        if annotation_type is not None:
+            config.data.annotation_type = annotation_type
 
         logger.info(f"Training configuration loaded: {config.training}")
 

--- a/niftilearn/config/loader.py
+++ b/niftilearn/config/loader.py
@@ -116,6 +116,10 @@ def apply_cli_overrides(config: Config, overrides: dict[str, Any]) -> Config:
             config_dict["training"]["learning_rate"] = overrides[
                 "learning_rate"
             ]
+        if "annotation_type" in overrides:
+            config_dict["data"]["annotation_type"] = overrides[
+                "annotation_type"
+            ]
 
         # Re-validate with overrides
         updated_config = Config(**config_dict)

--- a/niftilearn/config/models.py
+++ b/niftilearn/config/models.py
@@ -13,6 +13,9 @@ class DataConfig(BaseModel):
     annotation_dir: Path = Field(
         ..., description="Path to annotation directory"
     )
+    annotation_type: Literal["ART", "RA", "S_FAT"] = Field(
+        "ART", description="Target annotation type to load"
+    )
     train_split: float = Field(
         0.7, ge=0.0, le=1.0, description="Training split ratio"
     )

--- a/niftilearn/data/datamodule.py
+++ b/niftilearn/data/datamodule.py
@@ -27,7 +27,6 @@ class NiftiDataModule(pl.LightningDataModule):
         self,
         data_config: DataConfig,
         compute_config: ComputeConfig,
-        annotation_type: str = "ART",
         enable_caching: bool = False,
         cache_size: int = 10,
         random_seed: int = 42,
@@ -35,9 +34,8 @@ class NiftiDataModule(pl.LightningDataModule):
         """Initialize the NIFTI DataModule.
 
         Args:
-            data_config: Data processing configuration
+            data_config: Data processing configuration (includes annotation_type)
             compute_config: Compute configuration including num_workers
-            annotation_type: Target annotation type (e.g., 'ART', 'RA', 'S_FAT')
             enable_caching: Enable volume caching in datasets
             cache_size: Maximum number of volumes to cache per dataset
             random_seed: Random seed for reproducible splits
@@ -50,7 +48,7 @@ class NiftiDataModule(pl.LightningDataModule):
         # Store configuration
         self.data_config = data_config
         self.compute_config = compute_config
-        self.annotation_type = annotation_type
+        self.annotation_type = data_config.annotation_type
         self.enable_caching = enable_caching
         self.cache_size = cache_size
         self.random_seed = random_seed
@@ -72,7 +70,7 @@ class NiftiDataModule(pl.LightningDataModule):
             )
 
         logger.info(
-            f"NiftiDataModule initialized for annotation type: {annotation_type}"
+            f"NiftiDataModule initialized for annotation type: {self.annotation_type}"
         )
         logger.info(f"Data directory: {data_config.data_dir}")
         logger.info(


### PR DESCRIPTION
## Summary
Enable users to specify which annotation type (ART, RA, S_FAT) to load through YAML configuration files and CLI overrides.

This addresses the issue where users couldn't configure which annotation type to load without modifying code.

## Changes
- ✅ Add `annotation_type` field to `DataConfig` with validation for valid values
- ✅ Update `NiftiDataModule` to use `data_config.annotation_type` instead of constructor parameter
- ✅ Add `--annotation-type` CLI option with choices validation (`ART`, `RA`, `S_FAT`)
- ✅ Update all configuration examples to include `annotation_type` field
- ✅ Update CLI override logic in config loader to support annotation_type
- ✅ Update documentation and examples in README.md

## Usage Examples

**Via Configuration File:**
```yaml
data:
  annotation_type: "RA"  # Load rectus abdominus annotations
```

**Via CLI Override:**
```bash
niftilearn train --config myconfig.yaml --annotation-type S_FAT
```

**In Code:**
```python
config = load_config("config.yaml")  # annotation_type comes from config.data
datamodule = NiftiDataModule(config.data, config.compute)
```

## Test plan
- [x] Configuration loading works with new annotation_type field
- [x] CLI help shows new --annotation-type option with correct choices
- [x] Ruff linting passes
- [x] Backward compatibility maintained (defaults to "ART")